### PR TITLE
Add command for generating Python download script

### DIFF
--- a/python/bot_commands.py
+++ b/python/bot_commands.py
@@ -41,7 +41,7 @@ async def fremove(ctx: SlashContext or commands.Context,
         bot
     )
     if not manageable_files:
-        return f"I couldn't find any files related to `{filename}`"
+        return f"I couldn't find any files that you can access."
     res = await search_client.remove_doc(
         [file['objectID'] for file in manageable_files],
         serv_id,
@@ -74,7 +74,7 @@ async def fdelete(ctx: SlashContext or commands.Context, search_client: AsyncSea
     serv_id = ctx.channel.id
     if ctx.guild is not None:
         serv_id = ctx.guild.id
-    files = await search_client.search(filename, serv_id, ctx.channel, **kwargs)
+    files = await search_client.search(serv_id, **kwargs)
     manageable_files = filter_messages_with_permissions(
         author,
         files,
@@ -82,7 +82,7 @@ async def fdelete(ctx: SlashContext or commands.Context, search_client: AsyncSea
         bot
     )
     if not manageable_files:
-        return f"I couldn't find any files related to `{filename}`"
+        return f"I couldn't find any files that you can access."
     deleted_files = []
     await search_client.remove_doc(
         [file['objectID'] for file in manageable_files],

--- a/python/cog.py
+++ b/python/cog.py
@@ -158,8 +158,11 @@ class Discordfs(commands.Cog):
             DM: A bool for whether to dm the author the results.
         """
         recipient, files = await self.locate(ctx, **kwargs)
+        channels = {}
+        for c in ctx.guild.channels:
+            channels[str(c.id)] = c.name
 
-        with io.StringIO(generate_script(files)) as f:
+        with io.StringIO(generate_script(files, channels)) as f:
             await recipient.send(f"Run this script to download the {len(files)} files.", file=discord.File(f, filename="export.py"))
 
     @cog_ext.cog_slash(

--- a/python/cog.py
+++ b/python/cog.py
@@ -159,9 +159,11 @@ class Discordfs(commands.Cog):
             DM: A bool for whether to dm the author the results.
         """
         recipient, files = await self.locate(ctx, **kwargs)
+        needed_channel_ids = set(f["channel_id"] for f in files)
         channels = {}
         for c in ctx.guild.channels:
-            channels[str(c.id)] = c.name
+            if c.id in needed_channel_ids:
+                channels[str(c.id)] = c.name
         export_name = re.sub(r"[^A-Za-z0-9'\-\_ ]", "", ctx.guild.name)
         if export_name == "":
             # server name contains only unsupported characters

--- a/python/cog.py
+++ b/python/cog.py
@@ -21,6 +21,7 @@ from dateutil import parser
 import glob
 from typing import List, Dict, Tuple, Union
 import io
+import re
 
 guild_ids = []
 if getattr(CONFIG, "GUILD_ID", None):
@@ -161,8 +162,12 @@ class Discordfs(commands.Cog):
         channels = {}
         for c in ctx.guild.channels:
             channels[str(c.id)] = c.name
+        export_name = re.sub(r"[^A-Za-z0-9'\-\_ ]", "", ctx.guild.name)
+        if export_name == "":
+            # server name contains only unsupported characters
+            export_name = "export"
 
-        with io.StringIO(generate_script(files, channels)) as f:
+        with io.StringIO(generate_script(export_name, files, channels)) as f:
             await recipient.send(f"Run this script to download the {len(files)} files.", file=discord.File(f, filename="export.py"))
 
     @cog_ext.cog_slash(

--- a/python/cog.py
+++ b/python/cog.py
@@ -139,7 +139,7 @@ class Discordfs(commands.Cog):
 
     @cog_ext.cog_slash(
         name="export",
-        description="Get export script for files.",
+        description="Get Python export script to download the results to your computer.",
         options=search_options,
         guild_ids=guild_ids if getattr(CONFIG, "DB_NAME", "production") == "testing" else []
     )

--- a/python/cog.py
+++ b/python/cog.py
@@ -93,8 +93,8 @@ class Discordfs(commands.Cog):
         except:
             pass
 
-        if not any(list(kwargs.values())):
-            await ctx.send(f"You must specify a parameter to search on!", hidden=kwargs.get("dm", False))
+        if not kwargs:
+            await ctx.send(f"You must specify a parameter to search on!", hidden=False)
             return
 
         if kwargs.get("before"):

--- a/python/cog.py
+++ b/python/cog.py
@@ -32,6 +32,11 @@ formatter = logging.Formatter('%(asctime)s:%(levelname)s:%(name)s: %(message)s')
 fh.setFormatter(formatter)
 logger.addHandler(fh)
 
+EXP_TEMPLATE_SPLIT_IDX = 9
+export_template = []
+with open("python/export_template.py") as f:
+    export_template = f.readlines()
+
 
 class Discordfs(commands.Cog):
     """Main class for the bot."""
@@ -352,7 +357,16 @@ class Discordfs(commands.Cog):
             files: The files to send to the context.
         """
 
-        f = io.BytesIO(bytes(str(files), 'utf-8'))
+        script_top = export_template[0:EXP_TEMPLATE_SPLIT_IDX]
+        dict_strs = list(map(lambda d: str(d) + ',', files))
+        script_bottom = export_template[EXP_TEMPLATE_SPLIT_IDX:]
+        script_lines = []
+        script_lines.extend(script_top)
+        script_lines.extend(dict_strs)
+        script_lines.extend(script_bottom)
+        script = '\n'.join(script_lines)
+
+        f = io.BytesIO(bytes(script, 'utf-8'))
         await ctx.send(file=discord.File(f, filename="export.py"))
         f.close()
 

--- a/python/export_template.py
+++ b/python/export_template.py
@@ -1,14 +1,13 @@
 from typing import List, Dict
 
-template_top = """
-#!/usr/bin/env python3
+template_top = """#!/usr/bin/env python3.6
 
 # This script will download all the files you requested.
 # To run it, you will need Python 3 installed on your computer.
 # For Windows, you can install it from the MS store, or from
 # https://www.python.org/downloads/windows/
 # For macOS, you can install it from https://www.python.org/downloads/macos/
-# For Linux, use your distor's package manager.
+# For Linux, use your distro's package manager.
 # If you need help running the script, see
 # https://realpython.com/run-python-scripts/#how-to-run-python-scripts-using-the-command-line
 
@@ -25,6 +24,7 @@ headers = {
 }
 
 files = ["""
+
 template_bottom = """]
 
 if not os.path.exists(root_dir):
@@ -33,7 +33,7 @@ if not os.path.exists(root_dir):
 for f in files:
     path = os.path.join(root_dir, str(f["channel_id"]), f["file_name"])
     if os.path.exists(path):
-        print(f"Skipping {f['url']} (already downloaded)")
+        print(f"Skipping {f['file_name']} (already downloaded)")
         continue
     print(f"Fetching {f['url']}")
     finished = False
@@ -41,7 +41,11 @@ for f in files:
         req = request.Request(f["url"], {}, headers)
         with request.urlopen(req) as url:
             if url.status == HTTPStatus.TOO_MANY_REQUESTS:
-                retry_after = json.loads(url.body)["retry_after"]
+                try:
+                    retry_after = json.loads(url.body)["retry_after"]
+                except Exception as e:
+                    print(f"Error loading API response: {e}")
+                    retry_after = 5
                 print(f"Being rate limited, waiting for {retry_after} seconds")
                 sleep(retry_after)
                 continue

--- a/python/export_template.py
+++ b/python/export_template.py
@@ -2,6 +2,7 @@ from urllib import request
 import os
 
 
+root_dir = "discordfs-export"
 headers = {
     "User-Agent": "discordfs/1.0"
 }
@@ -10,13 +11,23 @@ files = [
 
 ]
 
+if not os.path.exists(root_dir):
+    os.mkdir(root_dir)
+
 for f in files:
+    path = os.path.join(root_dir, f["channel_name"], f["filename"])
+    if os.path.exists(path):
+        f"Skipping {f['url']} (already downloaded)"
+        continue
+    print(f"Fetching {f['url']}")
     req = request.Request(f["url"], {}, headers)
     with request.urlopen(req) as url:
+        if url.status == 429:
+            print("Timeout")
         b = url.read()
-        if not os.path.exists(f["channel_name"]):
-            os.mkdir(f["channel_name"])
-            path = os.path.join(f["channel_name"], f["filename"])
-            with open(path, "wb") as out:
-                out.write(b)
+        if not os.path.exists(os.path.join(root_dir, f["channel_name"])):
+            os.mkdir(os.path.join(root_dir, f["channel_name"]))
+        path = os.path.join(path)
+        with open(path, "wb") as out:
+            out.write(b)
 

--- a/python/export_template.py
+++ b/python/export_template.py
@@ -1,3 +1,17 @@
+from typing import List, Dict
+
+template_top = """
+#!/usr/bin/env python3
+
+# This script will download all the files you requested.
+# To run it, you will need Python 3 installed on your computer.
+# For Windows, you can install it from the MS store, or from
+# https://www.python.org/downloads/windows/
+# For macOS, you can install it from https://www.python.org/downloads/macos/
+# For Linux, use your distor's package manager.
+# If you need help running the script, see
+# https://realpython.com/run-python-scripts/#how-to-run-python-scripts-using-the-command-line
+
 from urllib import request
 import os
 
@@ -7,17 +21,16 @@ headers = {
     "User-Agent": "discordfs/1.0"
 }
 
-files = [
-
-]
+files = ["""
+template_bottom = """]
 
 if not os.path.exists(root_dir):
     os.mkdir(root_dir)
 
 for f in files:
-    path = os.path.join(root_dir, f["channel_name"], f["filename"])
+    path = os.path.join(root_dir, str(f["channel_id"]), f["file_name"])
     if os.path.exists(path):
-        f"Skipping {f['url']} (already downloaded)"
+        print(f"Skipping {f['url']} (already downloaded)")
         continue
     print(f"Fetching {f['url']}")
     req = request.Request(f["url"], {}, headers)
@@ -25,9 +38,14 @@ for f in files:
         if url.status == 429:
             print("Timeout")
         b = url.read()
-        if not os.path.exists(os.path.join(root_dir, f["channel_name"])):
-            os.mkdir(os.path.join(root_dir, f["channel_name"]))
+        if not os.path.exists(os.path.join(root_dir, str(f["channel_id"]))):
+            os.mkdir(os.path.join(root_dir, str(f["channel_id"])))
         path = os.path.join(path)
         with open(path, "wb") as out:
             out.write(b)
+"""
 
+def generate_script(files: List[Dict]) -> str:
+    """Generates the contents of a script file."""
+    dict_strs = list(map(lambda d: str(d) + ',', files))
+    return template_top + '\n'.join(dict_strs) + template_bottom

--- a/python/export_template.py
+++ b/python/export_template.py
@@ -8,8 +8,7 @@ template_top = """#!/usr/bin/env python3.6
 # https://www.python.org/downloads/windows/
 # For macOS, you can install it from https://www.python.org/downloads/macos/
 # For Linux, use your distro's package manager.
-# If you need help running the script, see
-# https://realpython.com/run-python-scripts/#how-to-run-python-scripts-using-the-command-line
+# If you need help running the script, see # https://realpython.com/run-python-scripts/#how-to-run-python-scripts-using-the-command-line
 
 from http import HTTPStatus
 from urllib import request
@@ -23,20 +22,19 @@ headers = {
     "User-Agent": "discordfs/1.0"
 }
 
-files = ["""
-
-template_middle = """]
-
-channels = """
+"""
 
 template_bottom = """
 
+root_path = os.path.join(root_dir, export_name)
 if not os.path.exists(root_dir):
     os.mkdir(root_dir)
+if not os.path.exists(root_path):
+    os.mkdir(root_path)
 
 for f in files:
     channel = channels[str(f["channel_id"])]
-    path = os.path.join(root_dir, channel, f["file_name"])
+    path = os.path.join(root_path, channel, f["file_name"])
     if os.path.exists(path):
         print(f"Skipping {f['file_name']} (already downloaded)")
         continue
@@ -59,15 +57,20 @@ for f in files:
                 finished = True
                 continue
             b = url.read()
-            if not os.path.exists(os.path.join(root_dir, channel)):
-                os.mkdir(os.path.join(root_dir, channel))
+            if not os.path.exists(os.path.join(root_path, channel)):
+                os.mkdir(os.path.join(root_path, channel))
             path = os.path.join(path)
             with open(path, "wb") as out:
                 out.write(b)
             finished = True
 """
 
-def generate_script(files: List[Dict], channels: Dict) -> str:
+def generate_script(export_name: str, files: List[Dict], channels: Dict) -> str:
     """Generates the contents of a script file."""
     dict_strs = list(map(lambda d: str(d) + ',', files))
-    return template_top + '\n'.join(dict_strs) + template_middle + str(channels) + template_bottom
+    template_middle = 'files = [\n'
+    template_middle += '\n'.join(dict_strs)
+    template_middle += ']\n'
+    template_middle += f'channels = {str(channels)}\n'
+    template_middle += f'export_name = "{export_name}"\n'
+    return template_top + template_middle + template_bottom

--- a/python/export_template.py
+++ b/python/export_template.py
@@ -25,13 +25,18 @@ headers = {
 
 files = ["""
 
-template_bottom = """]
+template_middle = """]
+
+channels = """
+
+template_bottom = """
 
 if not os.path.exists(root_dir):
     os.mkdir(root_dir)
 
 for f in files:
-    path = os.path.join(root_dir, str(f["channel_id"]), f["file_name"])
+    channel = channels[str(f["channel_id"])]
+    path = os.path.join(root_dir, channel, f["file_name"])
     if os.path.exists(path):
         print(f"Skipping {f['file_name']} (already downloaded)")
         continue
@@ -54,15 +59,15 @@ for f in files:
                 finished = True
                 continue
             b = url.read()
-            if not os.path.exists(os.path.join(root_dir, str(f["channel_id"]))):
-                os.mkdir(os.path.join(root_dir, str(f["channel_id"])))
+            if not os.path.exists(os.path.join(root_dir, channel)):
+                os.mkdir(os.path.join(root_dir, channel))
             path = os.path.join(path)
             with open(path, "wb") as out:
                 out.write(b)
             finished = True
 """
 
-def generate_script(files: List[Dict]) -> str:
+def generate_script(files: List[Dict], channels: Dict) -> str:
     """Generates the contents of a script file."""
     dict_strs = list(map(lambda d: str(d) + ',', files))
-    return template_top + '\n'.join(dict_strs) + template_bottom
+    return template_top + '\n'.join(dict_strs) + template_middle + str(channels) + template_bottom

--- a/python/export_template.py
+++ b/python/export_template.py
@@ -1,0 +1,22 @@
+from urllib import request
+import os
+
+
+headers = {
+    "User-Agent": "discordfs/1.0"
+}
+
+files = [
+
+]
+
+for f in files:
+    req = request.Request(f["url"], {}, headers)
+    with request.urlopen(req) as url:
+        b = url.read()
+        if not os.path.exists(f["channel_name"]):
+            os.mkdir(f["channel_name"])
+            path = os.path.join(f["channel_name"], f["filename"])
+            with open(path, "wb") as out:
+                out.write(b)
+


### PR DESCRIPTION
Sorry for not filling this in originally, I mistakenly made the PR on this instead of our fork, whoops :). To copy the description in the comment below:

We're making an /export command, which uses the same syntax as /search, but returns a python script, that when run, will download all of the files located. It's not complete yet, but feedback would still be helpful :)