### PR TITLE
removed try-catch + edited guild_id ternary operator

### DIFF
--- a/python/mongo_client.py
+++ b/python/mongo_client.py
@@ -179,26 +179,23 @@ class MgClient:
             return 0
         files_coll = self.db.files
         files_added = 0
-        try:
-            # We've already added the files in this message id
-            num_docs = await files_coll.count_documents({"message_id": message.id}, limit=1)
-            if num_docs:
-                return True
-            for file in message.attachments:
-                # We've already added this file
-                n_doc = await files_coll.count_documents({"_id": file.id}, limit=1)
-                if n_doc:
-                    continue
-                file_info = utils.attachment_to_mongo_dict(message, file)
-                res = await files_coll.insert_one(file_info)
-                if res.acknowledged:
-                    logger.info(f"Inserted new file: {res.inserted_id} with file id: {file.id}")
-                    files_added += 1
-                else:
-                    logger.error(f"Failed to insert file with _id: {file.id}")
-            return files_added
-        except:
-            return 0
+        # We've already added the files in this message id
+        num_docs = await files_coll.count_documents({"message_id": message.id}, limit=1)
+        if num_docs:
+            return True
+        for file in message.attachments:
+            # We've already added this file
+            n_doc = await files_coll.count_documents({"_id": file.id}, limit=1)
+            if n_doc:
+                continue
+            file_info = utils.attachment_to_mongo_dict(message, file)
+            res = await files_coll.insert_one(file_info)
+            if res.acknowledged:
+                logger.info(f"Inserted new file: {res.inserted_id} with file id: {file.id}")
+                files_added += 1
+            else:
+                logger.error(f"Failed to insert file with _id: {file.id}")
+        return files_added
 
     async def remove_file(self, ids: List[str], field: str = "_id") -> bool:
         """

--- a/python/utils.py
+++ b/python/utils.py
@@ -255,7 +255,7 @@ def attachment_to_mongo_dict(message: discord.Message, file: discord.Attachment)
         "author": message.author.id,
         "author_name": message.author.name + '#' + str(message.author.discriminator),
         "channel_id": message.channel.id,
-        "guild_id": message.guild.id if message.guild.id is not None else -1,
+        "guild_id": message.guild.id if message.guild is not None else -1,
         "content": message.content,
         "created_at": message.created_at,
         "file_name": file.filename,


### PR DESCRIPTION
# Problem

Files provided in direct messages with the bot are not being stored within the mongo db client.

# Solution

This issue is caused by these 2 chunks of code: [one](https://github.com/Mandaranian-Cactus/haystackfs/blob/main/python/utils.py#L258), and [two](https://github.com/Mandaranian-Cactus/haystackfs/blob/main/python/mongo_client.py#L182-L201). Since dms lack a `message.guild` field, an error will be raised in the 1st snippet because ur trying to access `message.guild.id` in the first snippet. This raises an error in the console and prevents dm files from being saved within the mongoDB client. However, this error isn't caught because the 2nd snippet ignores the error in try-except block.

Solution is to rewrite the ternary operator in snipper one.

# Next Steps

NA
