### PR TITLE
Delete indices files on discord message delete

### DIFF
--- a/python/cog.py
+++ b/python/cog.py
@@ -368,6 +368,7 @@ class Discordfs(commands.Cog):
         Args:
             payload: A discord.RawMessageDeleteEvent event.
         """
+        await self.search_client.remove_doc(payload.message_id, payload.guild_id, payload.channel_id)
         await self.db_client.remove_file([payload.message_id], field="message_id")
 
     @commands.Cog.listener()


### PR DESCRIPTION
# Problem

When a files is deleted in a discord server of direct message channel, the file's index still remains inside of the `indices` folder. We would like to remove the indexes of deleted files from the `indices` folder.

# Solution

Edit `PastFileSearch.remove_doc` to also remove files from `indices`

# Next Steps

Na
