### PR TITLE
store /search command in mongo db

### DIFF
--- a/python/cog.py
+++ b/python/cog.py
@@ -183,6 +183,7 @@ class Discordfs(commands.Cog):
         options=search_options,
         guild_ids=guild_ids if getattr(CONFIG, "DB_NAME", "production") == "testing" else []
     )
+    @log_command
     async def slash_search(self, ctx: SlashContext, **kwargs):
         """
         Responds to `/search`. Tries to display docs related to a query from ElasticSearch.


### PR DESCRIPTION
# Problem

We want `slash_search` to log the command into the mongoldb client.

# Solution

Following the current convention for `slash_remove` and `slash_delete`, we add the `@log_command` decorator to `slash_search`. Now `log_command` is called to manage search commands.

# Next Steps
Since log_command decorator is used, this means that [`log_command`](https://github.com/dhrumilp15/haystackfs/blob/main/python/mongo_client.py#L49) is called prior to [`DiscordFS.locate`](https://github.com/dhrumilp15/haystackfs/blob/main/python/cog.py#L145). This means that `ctx.defer(hidden=kwargs.get("dm", False))` is called after the slash command has been saved to the data base by `log_command`. This can be an issue if `log_command` takes too long which will raise a time out error by the discord api (Top answer [here](https://stackoverflow.com/questions/68363527/discord-py-slash-commands-this-interaction-failed-on-long-running-functions)).

TLDR: Defering the msg should be called first before we store the command or anything else.
